### PR TITLE
Add a tsconf.json file to the scripts folder that configures tsc to target ES5.

### DIFF
--- a/Sample-App/scripts/tsconfig.json
+++ b/Sample-App/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+        "out": "www/scripts/appBundle.js",
+        "sourceMap": true,
+        "removeComments": true,
+        "sourceRoot": "/"
+    }
+}


### PR DESCRIPTION
This is done in order to fix the getter/setter not available issue that appears when building
the project with the released version of VisualStudio 2015.
