### PR TITLE
Fixed 310x310 icon dimensions

### DIFF
--- a/Sample-App/config.xml
+++ b/Sample-App/config.xml
@@ -49,7 +49,7 @@
     <icon src="res/icons/windows/Square150x150Logo.scale-100.png" width="150" height="150" />
     <icon src="res/icons/windows/Square150x150Logo.scale-240.png" width="360" height="360" />
     <icon src="res/icons/windows/Square30x30Logo.scale-100.png" width="30" height="30" />
-    <icon src="res/icons/windows/Square310x310Logo.scale-100.png" width="" height="" />
+    <icon src="res/icons/windows/Square310x310Logo.scale-100.png" width="310" height="310" />
     <icon src="res/icons/windows/Square44x44Logo.scale-240.png" width="106" height="106" />
     <icon src="res/icons/windows/Square70x70Logo.scale-100.png" width="70" height="70" />
     <icon src="res/icons/windows/Square71x71Logo.scale-240.png" width="170" height="170" />


### PR DESCRIPTION
This was a fix in the VS2015 Cordova project template between RC and RTM.
