### PR TITLE
ShowSpinner to false bug

### DIFF
--- a/Sample-App/scripts/Services/HttpInterceptor.ts
+++ b/Sample-App/scripts/Services/HttpInterceptor.ts
@@ -385,7 +385,8 @@
                 // If there are no more spinner requests in progress, then hide the spinner.
                 NProgress.done();
             }
-            else {
+            // If showSpinner is false don't show NProgress bar
+            else if (config.showSpinner) {
                 // If there are still spinner requests in progress, then kick up the progress
                 // bar a little bit to show some of the work has completed.
                 NProgress.inc();


### PR DESCRIPTION
An httpRequest with option showSpinner to false make that NProgress are show and never hides when the request response
#71
